### PR TITLE
[CDF-116] Increase sequence precision

### DIFF
--- a/target_redshift/sinks.py
+++ b/target_redshift/sinks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import datetime
 import os
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable
 
@@ -400,3 +401,23 @@ class RedshiftSink(SQLSink):
                 _ = self.s3_client.delete_object(Bucket=self.config["s3_bucket"], Key=self.s3_key())
             except ClientError:
                 self.logger.exception()
+
+    def _add_sdc_metadata_to_record(
+        self,
+        record: dict,
+        message: dict,
+        context: dict,
+    ) -> None:
+        """Populate metadata _sdc columns from incoming record message.
+
+        Record metadata specs documented at:
+        https://sdk.meltano.com/en/latest/implementation/record_metadata.html
+
+        Args:
+            record: Individual record in the stream.
+            message: The record message.
+            context: Stream partition or context dictionary.
+        """
+        super()._add_sdc_metadata_to_record(record, message, context)
+
+        record["_sdc_sequence"] = time.time_ns()


### PR DESCRIPTION
## What
* Increase `_sdc_sequence` from milliseconds since epoch to nanoseconds since epoch
  * Original code for the function https://github.com/meltano/sdk/blob/f098210da0edcfa336fe7955280d6d9d67955544/singer_sdk/sinks/core.py#L434-L461

## Why
* In [this PR](https://github.com/recruiting-tech/target-redshift/pull/7/files), we deal with multiple changes to one primary key in the same run by ordering on `_sdc_sequence`. However, `_sdc_sequence` is time-based and can have the same value for two entries if they are processed in the same millisecond. Increasing this to nanosecond makes `_sdc_sequence` unique